### PR TITLE
Allow single-line comment at end of file

### DIFF
--- a/CppHeaderParser/CppHeaderParser.py
+++ b/CppHeaderParser/CppHeaderParser.py
@@ -125,7 +125,7 @@ t_EXCLAMATION = r'!'
 t_PRECOMP_MACRO = r'\#.*'
 t_PRECOMP_MACRO_CONT = r'.*\\\n'
 def t_COMMENT_SINGLELINE(t):
-    r'\/\/.*\n'
+    r'\/\/.*\n?'
     global doxygenCommentCache
     if t.value.startswith("///") or t.value.startswith("//!"):
         if doxygenCommentCache:

--- a/CppHeaderParser/test/test_CppHeaderParser.py
+++ b/CppHeaderParser/test/test_CppHeaderParser.py
@@ -1791,8 +1791,19 @@ class HALControlWord_TestCase(unittest.TestCase):
     def test_num_typedefs(self):
         self.assertEqual(len(self.cppHeader.typedefs), 1)
         self.assertEqual(self.cppHeader.typedefs["HAL_ControlWord"], "struct HAL_ControlWord")
-    
-    
+
+# Bitbucket bug 47
+class CommentEOF_TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.cppHeader = CppHeaderParser.CppHeader("""
+namespace a {
+}  // namespace a""", "string")
+
+    def test_comment(self):
+        self.assertTrue('a' in self.cppHeader.namespaces)
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
- Fixes https://bitbucket.org/senex/cppheaderparser/issues/47/error-with-ending-file-with-a-comment