### PR TITLE
Adding flag to identify vararg functions

### DIFF
--- a/CppHeaderParser/test/TestSampleClass.h
+++ b/CppHeaderParser/test/TestSampleClass.h
@@ -768,3 +768,8 @@ struct Grackle
     void noexcept_noexceptOperator() noexcept(noexcept(Grackle()));
     void const_noexcept_noexceptOperator() const noexcept(noexcept(Grackle()));
 };
+
+// Two prototypes that are the same apart from the ...
+int vararg_func(int foo, const char* fmt, ...);
+
+int non_vararg_func(int foo, const char* fmt);

--- a/CppHeaderParser/test/test_CppHeaderParser.py
+++ b/CppHeaderParser/test/test_CppHeaderParser.py
@@ -1837,6 +1837,19 @@ class Grackle_TestCase(unittest.TestCase):
         self.assertEqual(self.cppHeader.classes["Grackle"]["methods"]["public"][6]["noexcept"], 'noexcept(noexcept(Grackle()))')
 
 
+class VarargFunc_TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.cppHeader = CppHeaderParser.CppHeader("TestSampleClass.h")
+
+    def test_vararg_func(self):
+        vf = next(x for x in self.cppHeader.functions if x['name'] == 'vararg_func')
+        nvf = next(x for x in self.cppHeader.functions if x['name'] == 'non_vararg_func')
+        self.assertTrue(vf['vararg'])
+        self.assertFalse(nvf['vararg'])
+        self.assertEqual(len(vf['parameters']), len(nvf['parameters']));
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
There seemed to be no existing indication when encountering printf-like functions that they accept variable arguments. It was previously possible to infer this from the debug field because it would mistakenly show the prototype as ending with a  ",)" having detected the trailing "..." as a parameter, but then not used it successfully.