### PR TITLE
Ensure license file is included in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+# Include the license file in wheels.
+license_file = LICENSE.txt


### PR DESCRIPTION
Since we upload wheels to PyPI, they should include the license.