### PR TITLE
Line number information for #pragmas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 dist: xenial
 
 python:
@@ -8,18 +7,16 @@ python:
   - "3.5"
   - "2.7"
 
-matrix:
-  fast_finish: true
 
 jobs:
   include:
   - stage: format-check
-    python:
-    - "3.6"
+    python: "3.6"
     install:
     - pip install black
     script:
     - black --check --diff .
+  fast_finish: true
 
 # command to install dependencies
 install:

--- a/test/test_CppHeaderParser.py
+++ b/test/test_CppHeaderParser.py
@@ -1869,15 +1869,27 @@ class Macro_TestCase(unittest.TestCase):
 
     def test_includes(self):
         self.assertEqual(self.cppHeader.includes, ["<string.h>", '"../../debug.h"'])
+        self.assertEqual(self.cppHeader.includes_detail[0]["value"], "<string.h>")
+        self.assertEqual(self.cppHeader.includes_detail[0]["line_number"], 2)
+        self.assertEqual(self.cppHeader.includes_detail[1]["value"], '"../../debug.h"')
+        self.assertEqual(self.cppHeader.includes_detail[1]["line_number"], 3)
 
     def test_pragmas(self):
         self.assertEqual(self.cppHeader.pragmas, ["once"])
+        self.assertEqual(self.cppHeader.pragmas_detail[0]["value"], "once")
+        self.assertEqual(self.cppHeader.pragmas_detail[0]["line_number"], 7)
 
     def test_pragmas0(self):
         self.assertEqual(self.cppHeader.defines[0], "ONE 1")
+        self.assertEqual(self.cppHeader.defines_detail[0]["value"], "ONE 1")
+        self.assertEqual(self.cppHeader.defines_detail[0]["line_number"], 5)
 
     def test_pragmas1(self):
         self.assertEqual(self.cppHeader.defines[1], 'TWO_NUM_N_NAME "2 (TWO)"')
+        self.assertEqual(
+            self.cppHeader.defines_detail[1]["value"], 'TWO_NUM_N_NAME "2 (TWO)"'
+        )
+        self.assertEqual(self.cppHeader.defines_detail[1]["line_number"], 6)
 
     def test_pragmas2(self):
         self.assertEqual(


### PR DESCRIPTION
I've added capturing of line number information for pragmas, defines and includes. I've left the existing lists of strings untouched to preserve the existing interface and added new members to store the additional information