### PR TITLE
Bug-Fix for multi-keyword variable-list parsing for properties

### DIFF
--- a/CppHeaderParser/CppHeaderParser.py
+++ b/CppHeaderParser/CppHeaderParser.py
@@ -2458,11 +2458,38 @@ class _CppHeader(Resolver):
                         self.nameStack,
                         ".  Separating processing",
                     )
-                    orig_nameStack = self.nameStack[:]
+                    i = leftMostComma - 2 # start right before the first var name
+                    typeFound = []
+                    typeEndIndex = 0
 
-                    type_nameStack = orig_nameStack[: leftMostComma - 1]
-                    for name in orig_nameStack[leftMostComma - 1 :: 2]:
-                        self.nameStack = type_nameStack + [name]
+                    while not i < 0: # find the type by assuming that the first non-ptr/ref related word before the first varname has to be the end of the type stack
+                        if self.nameStack[i] == "*" or self.nameStack[i] == "&":
+                            if i > 0 and self.nameStack[i - 1] == "const": # handle declarations like "int const& const_int_ref;" correctly
+                                i -= 1; # skip next const
+                        else: # the real type declaration starts (ends) at index i
+                            typeEndIndex = i + 1
+                            typeFound.extend(self.nameStack[0:i + 1])
+
+                            break
+
+                        i-= 1
+
+                    nameStacks = []
+                    currStack = typeFound.copy()
+
+                    for word in self.nameStack[typeEndIndex:]:
+                        if word == ",":
+                            nameStacks.append(currStack)
+                            currStack = typeFound.copy() # reset currStack
+                            continue
+
+                        currStack.append(word)
+
+                    if not currStack == typeFound: # add last var in the list
+                        nameStacks.append(currStack)
+
+                    for nameStack in nameStacks:
+                        self.nameStack = nameStack
                         self._evaluate_property_stack(
                             clearStack=False, addToVar=addToVar
                         )

--- a/test/TestSampleClass.h
+++ b/test/TestSampleClass.h
@@ -52,7 +52,7 @@ private:
 
     double prop7;   //!< prop7 description
                     //!< with two lines
-    
+
     /// prop8 description
     int prop8;
 };
@@ -642,6 +642,7 @@ public:
     int a, b,c;
     map<string, int> d;
     map<string, int> e, f;
+		const int* g, const& h, const* i, j;
 };
 
 // Bug BitBucket #14
@@ -719,7 +720,7 @@ struct Lemon
     virtual void foo() final;
     virtual void foo2();
 };
- 
+
 struct Lime final : Lemon
 {
     void abc();
@@ -749,12 +750,12 @@ union olive {
 
 // Sourceforge bug 61
 typedef struct
-{ 
-    enum BeetEnum : int 
-    { 
+{
+    enum BeetEnum : int
+    {
         FAIL = 0,
         PASS = 1
-    }; 
+    };
 } BeetStruct;
 
 void set_callback(int* b, long (*callback) (struct test_st *, int, const char*, int long, long, long));

--- a/test/test_CppHeaderParser.py
+++ b/test/test_CppHeaderParser.py
@@ -1752,7 +1752,7 @@ class functions_TestCase(unittest.TestCase):
     def setUp(self):
         self.cppHeader = CppHeaderParser.CppHeader(
             """\
-              void global_funct1(int i);             
+              void global_funct1(int i);
               int global_funct2(void);
               """,
             "string",
@@ -1787,7 +1787,7 @@ class functions2_TestCase(unittest.TestCase):
     def setUp(self):
         self.cppHeader = CppHeaderParser.CppHeader(
             """\
-              void global_funct1(int i);             
+              void global_funct1(int i);
               int global_funct2(void){
                   // do something
               }
@@ -2171,6 +2171,45 @@ class Grape_TestCase(unittest.TestCase):
             self.cppHeader.classes["Grape"]["properties"]["public"][5]["name"], "f"
         )
 
+    def test_g_exists(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][6]["name"], "g"
+        )
+
+    def test_g_type(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][6]["type"], "const int *"
+        )
+
+    def test_h_exists(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][7]["name"], "h"
+        )
+
+    def test_h_type(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][7]["type"], "const int const &"
+        )
+
+    def test_i_exists(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][8]["name"], "i"
+        )
+
+    def test_i_type(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][8]["type"], "const int const *"
+        )
+
+    def test_j_exists(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][9]["name"], "j"
+        )
+
+    def test_j_type(self):
+        self.assertEqual(
+            self.cppHeader.classes["Grape"]["properties"]["public"][9]["type"], "const int"
+        )
 
 # Bug BitBucket #14
 class Avacado_TestCase(unittest.TestCase):
@@ -2433,7 +2472,7 @@ struct Lemon
     virtual void foo() final;
     virtual void foo2();
 };
- 
+
 struct Lime final : Lemon
 {
     void abc();
@@ -3488,7 +3527,7 @@ class StaticAssert_TestCase(unittest.TestCase):
     def setUp(self):
         self.cppHeader = CppHeaderParser.CppHeader(
             """
-static_assert(sizeof(int) == 4, 
+static_assert(sizeof(int) == 4,
               "integer size is wrong"
               "for some reason");
 """,
@@ -3511,7 +3550,7 @@ struct ComplexInit : SomeBase {
   }
 
   void fn();
-  
+
   std::vector<int> m_stuff;
 };
 
@@ -3859,7 +3898,7 @@ class NestedTypedef(unittest.TestCase):
 template <class SomeType> class A {
  public:
   typedef B <SomeType> C;
-  
+
   A();
 
  protected:


### PR DESCRIPTION
If you try parsing a class containing a variable-list which has more then one keyword like below
`
class Test {
public:
   int* test1, * test2, * test3;
};
`
The parser will fail because it assumes a single "var-pair" only consists of the name and the seperator.
This approach will fail if tried on a case like above and will cause even more issues if extra modifiers like "const" are used.
The parsers also incorrectly assumes:
`int * p1, p2;`
boils down to:
`
int* p1;
int* p2;
`
which is also incorrect since the Cpp-compiler will parse it to:
`
int* p1;
int p2;
`
The commit tries to address these issues by modifying the component responsible for parsing variable-lists inside CppHeader::_evaluate_property_stack.
The commit also contains tests for the changes and doesn't cause any issues with the original tests.