### PR TITLE
Fixing type reference to self

### DIFF
--- a/CppHeaderParser/CppHeaderParser.py
+++ b/CppHeaderParser/CppHeaderParser.py
@@ -3707,17 +3707,22 @@ class CppHeader(_CppHeader):
     def toJSON(self, indent=4, separators=None):
         """Converts a parsed structure to JSON"""
         import json
+
         self._strip_parent_keys()
-        def clean_dict(markers, keys = []):
-            if (id(markers) in keys):
+
+        def clean_dict(markers, keys=[]):
+            if id(markers) in keys:
                 return None
             elif isinstance(markers, dict):
                 keys_ = keys + [id(markers)]
-                return {key: clean_dict(markers[key], keys_) for 
-                    key, value in markers.items()}
+                return {
+                    key: clean_dict(markers[key], keys_)
+                    for key, value in markers.items()
+                }
             elif type(markers) in [list, set, tuple]:
                 return type(markers)(clean_dict(m, keys) for m in markers)
             return markers
+
         try:
             del self.__dict__["classes_order"]
         except:
@@ -3725,7 +3730,7 @@ class CppHeader(_CppHeader):
 
         d = self.__dict__
         d["classes"] = clean_dict(d["classes"])
-        return json.dumps(d, indent=indent, separators=separators, default = "")
+        return json.dumps(d, indent=indent, separators=separators, default="")
 
     def __repr__(self):
         rtn = {

--- a/CppHeaderParser/CppHeaderParser.py
+++ b/CppHeaderParser/CppHeaderParser.py
@@ -3707,13 +3707,25 @@ class CppHeader(_CppHeader):
     def toJSON(self, indent=4, separators=None):
         """Converts a parsed structure to JSON"""
         import json
-
         self._strip_parent_keys()
+        def clean_dict(markers, keys = []):
+            if (id(markers) in keys):
+                return None
+            elif isinstance(markers, dict):
+                keys_ = keys + [id(markers)]
+                return {key: clean_dict(markers[key], keys_) for 
+                    key, value in markers.items()}
+            elif type(markers) in [list, set, tuple]:
+                return type(markers)(clean_dict(m, keys) for m in markers)
+            return markers
         try:
             del self.__dict__["classes_order"]
         except:
             pass
-        return json.dumps(self.__dict__, indent=indent, separators=separators)
+
+        d = self.__dict__
+        d["classes"] = clean_dict(d["classes"])
+        return json.dumps(d, indent=indent, separators=separators, default = "")
 
     def __repr__(self):
         rtn = {


### PR DESCRIPTION
There seems to be a bug for some functions that reference the type itself. For instance, running the parser against the struct `A` shown below will result in a "Circular reference detected" during the JSON encoding step:

```C++
struct A{
        bool operator==(const A& other) const {
                return true;
        }
};
```

This PR solves this issue by removing any circular references in the dictionary before passing to the JSON.