### PR TITLE
Add access property to 'using' CppVariable

### DIFF
--- a/CppHeaderParser/CppHeaderParser.py
+++ b/CppHeaderParser/CppHeaderParser.py
@@ -1204,6 +1204,7 @@ class CppVariable(_CppVariable):
     * ``extern`` - True if its an extern, False if not
     * ``parent`` - If not None, either the class this is a property of, or the
       method this variable is a parameter in
+    * ``access`` - Anything in supportedAccessSpecifier
     """
 
     Vars = []
@@ -1320,6 +1321,7 @@ class CppVariable(_CppVariable):
             "desc",
             "line_number",
             "extern",
+            "access",
         ]
         cpy = dict((k, v) for (k, v) in list(self.items()) if k in keys_white_list)
         if "array_size" in self:
@@ -3382,6 +3384,7 @@ class CppHeader(_CppHeader):
                 else:
                     atype["raw_type"] = ns + atype["type"]
 
+                atype["access"] = self.curAccessSpecifier
                 if self.curClass:
                     klass = self.classes[self.curClass]
                     klass["using"][alias] = atype

--- a/test/test_CppHeaderParser.py
+++ b/test/test_CppHeaderParser.py
@@ -4015,6 +4015,7 @@ class UsingTypename(unittest.TestCase):
         self.cppHeader = CppHeaderParser.CppHeader(
             """
 template <class D> class P {
+using A = typename f::TP<D>::A;
 public:
   using State = typename f::TP<D>::S;
   P(State st);
@@ -4026,9 +4027,15 @@ public:
     def test_fn(self):
         c = self.cppHeader.classes["P"]
         self.assertEqual("P", c["name"])
+        self.assertEqual(len(c["using"]), 2)
         state = c["using"]["State"]
         self.assertEqual(state["raw_type"], "typename f::TP<D >::S")
         self.assertEqual(state["type"], "typename TP<D >::S")
+        self.assertEqual(state["access"], "public")
+        private = c["using"]["A"]
+        self.assertEqual(private["raw_type"], "typename f::TP<D >::A")
+        self.assertEqual(private["type"], "typename TP<D >::A")
+        self.assertEqual(private["access"], "private")
 
         m = c["methods"]["public"][0]
         self.assertEqual(m["name"], "P")


### PR DESCRIPTION
properties, typedefs, etc. are stored in a dict where the key is the access specifier. But for `using`, the key is the variable name.

Unless I missed it, for `using` there is currently no way to get the access specifier... so this PR intends to add it.