### PR TITLE
Fix enum parsing bug regarding decimal digit characters

### DIFF
--- a/CppHeaderParser/CppHeaderParser.py
+++ b/CppHeaderParser/CppHeaderParser.py
@@ -1350,7 +1350,8 @@ class _CppEnum(dict):
                 # Remove single quotes from single quoted chars (unless part of some expression
                 if len(a) == 3 and a[0] == "'" and a[2] == "'":
                     a = v["value"] = a[1]
-                if a.lower().startswith("0x"):
+                    a = i = ord(a)
+                elif a.lower().startswith("0x"):
                     try:
                         i = a = int(a, 16)
                     except:

--- a/test/TestSampleClass.h
+++ b/test/TestSampleClass.h
@@ -74,6 +74,7 @@ namespace Alpha
     		Z_C = 'j',
 			Z_D,
          Z_E = '9',
+         Z_F = 9,
     	} Zebra;
     };
 

--- a/test/TestSampleClass.h
+++ b/test/TestSampleClass.h
@@ -73,6 +73,7 @@ namespace Alpha
     		Z_B = 0x2B,
     		Z_C = 'j',
 			Z_D,
+         Z_E = '9',
     	} Zebra;
     };
 

--- a/test/test_CppHeaderParser.py
+++ b/test/test_CppHeaderParser.py
@@ -419,6 +419,7 @@ class AlphaClass_Zebra_TestCase(unittest.TestCase):
                 {"name": "Z_C", "raw_value": "j", "value": 106},
                 {"name": "Z_D", "value": 107},
                 {"name": "Z_E", "raw_value": "9", "value": 57},
+                {"name": "Z_F", "value": 9},
             ],
         )
 

--- a/test/test_CppHeaderParser.py
+++ b/test/test_CppHeaderParser.py
@@ -418,6 +418,7 @@ class AlphaClass_Zebra_TestCase(unittest.TestCase):
                 {"name": "Z_B", "raw_value": "0x2B", "value": 43},
                 {"name": "Z_C", "raw_value": "j", "value": 106},
                 {"name": "Z_D", "value": 107},
+                {"name": "Z_E", "raw_value": "9", "value": 57},
             ],
         )
 


### PR DESCRIPTION
Currently if I have an enum of the form
```c++
enum Foobar
{
    A_t = 9,
    B_t = '9'
};
```
CppHeaderParser will parse out the enum values as
```python
[
    {"name": "A_t", "value": 9},
    {"name": "B_t", "value": 9}
]
```

Clearly this is wrong, the enum values should be
```python
[
    {"name": "A_t", "value": 9},
    {"name": "B_t", "raw_value": "9", "value": 57}
]
```
where B_t represents the Unicode value for the character "9" (and not the actual integer value 9).

This PR includes the changes necessary to fix the enum parse logic. I've also updated a unit test to check this case and it passes with these changes.